### PR TITLE
fiat shamir: rm useless `TOTAL_GRINDING_TIME`

### DIFF
--- a/crates/fiat-shamir/src/lib.rs
+++ b/crates/fiat-shamir/src/lib.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-use std::{
-    sync::{Mutex, OnceLock},
-    time::Duration,
-};
+use std::time::Duration;
 
 use rand::{
     Rng, SeedableRng,
@@ -29,22 +26,6 @@ pub struct FsVerifier {
     state: KeccakDigest,
     transcript: Vec<u8>,
     cursor: usize,
-}
-
-static TOTAL_GRINDING_TIME: OnceLock<Mutex<Duration>> = OnceLock::new();
-
-pub fn get_total_grinding_time() -> Duration {
-    *TOTAL_GRINDING_TIME
-        .get_or_init(|| Mutex::new(Duration::default()))
-        .lock()
-        .unwrap()
-}
-
-pub fn reset_total_grinding_time() {
-    *TOTAL_GRINDING_TIME
-        .get_or_init(|| Mutex::new(Duration::default()))
-        .lock()
-        .unwrap() = Duration::default();
 }
 
 impl FsProver {
@@ -125,11 +106,6 @@ impl FsProver {
         if grinding_time > Duration::from_millis(10) {
             tracing::warn!("long PoW grinding: {} ms", grinding_time.as_millis());
         }
-        let mut total_time = TOTAL_GRINDING_TIME
-            .get_or_init(Default::default)
-            .lock()
-            .unwrap();
-        *total_time += grinding_time;
 
         self.add_bytes(&nonce.to_be_bytes());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,14 @@
 mod examples;
 
 use air::AirSettings;
-use examples::poseidon2::{SupportedField, prove_poseidon2_with};
+use examples::poseidon2::SupportedField;
 use whir_p3::parameters::{FoldingFactor, errors::SecurityAssumption};
 
 const SECURITY_BITS: usize = 100; // (temporary)
 
 fn main() {
     let (log_n_rows, log_inv_rate) = (16, 1);
-    let benchmark = prove_poseidon2_with(
-        SupportedField::KoalaBear,
+    let benchmark = SupportedField::KoalaBear.prove_poseidon2_with(
         log_n_rows,
         AirSettings::new(
             SECURITY_BITS,


### PR DESCRIPTION
As we will remove this version of fiat shamir to call the one of the whir backend, this is a first small step